### PR TITLE
chore: fix node v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "index.js"
   ],
   "devDependencies": {
-    "eslint": "^5.16.0",
+    "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
-    "mocha": "^6.1.4",
+    "mocha": "^5.2.0",
     "shelljs": "^0.8.1",
     "shelljs-changelog": "^0.2.2",
     "shelljs-release": "^0.2.0",


### PR DESCRIPTION
Downgrade mocha and eslint for node v4.