### PR TITLE
fix: rename export attribute for deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,4 +16,6 @@ plugin.register(inspectAttribute, inspect, {
   wrapOutput: false,
 });
 
-exports.inspect = inspect;
+// Note: this must not be named 'exports.inspect' otherwise this will trigger
+// the deprecation warning!
+exports.customInspect = inspect;

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,7 @@ describe('plugin-inspect', function () {
      * A plugin author can also export the implementation of their commands
      */
     pluginInspect.should.be.type('object');
-    pluginInspect.inspect.should.be.type('function');
+    pluginInspect.customInspect.should.be.type('function');
   });
 
   it('gets added as a method on ShellStrings', function () {


### PR DESCRIPTION
This renames the export attribute because naming it `.inspect` is enough
to trigger the deprecation warning.

This cannot be covered by an automated test because the deprecation only
fires when loading the module in an interactive REPL.

Fixes #9
Test: run `node` and `require('.')`