### PR TITLE
doc: generalize the docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 [![npm](https://img.shields.io/npm/v/shelljs-plugin-inspect.svg?style=flat-square)](https://www.npmjs.com/package/shelljs-plugin-inspect)
 [![shelljs-plugin](https://img.shields.io/badge/shelljs-plugin-brightgreen.svg?style=flat-square)](https://github.com/shelljs/shelljs/wiki/Using-ShellJS-Plugins)
 
-A [ShellJS](https://github.com/shelljs/shelljs) plugin to add `.inspect()`
-methods for REPL use.
+A [ShellJS](https://github.com/shelljs/shelljs) plugin to add custom REPL
+inspection for ShellJS output. This turns hard-to-read `ShellString` objects
+into nicely formatted text (resembling what the actual unix commands would
+output).
 
 ## Installation
 
@@ -14,14 +16,17 @@ $ npm install --save shelljs
 $ npm install --save shelljs-plugin-inspect
 ```
 
+**Tip:** If you want to use this plugin (and more REPL goodies), check out my
+project [n\_shell](https://github.com/nfischer/n_shell) to get a REPL with
+ShellJS loaded by default!
+
 ## Usage
 
-Use this plugin in a Node REPL like so:
-
-Without this plugin:
+Here's what ShellJS looks like by default in the REPL:
 
 ```javascript
-> shell.cat('file1.txt'); // Yuck!
+> // Before this plugin: hard-to-read ShellString objects
+> shell.cat('file1.txt');
 { [String: 'These are the file contents\nAnd they\'re printed out nicely!\n']
   stdout:'These are the file contents\nAnd they\'re printed out nicely!\n',
   stderr: null,
@@ -41,6 +46,7 @@ Without this plugin:
 After:
 
 ```
+> // After this plugin: nicely formatted text!
 > require('shelljs-plugin-inspect');
 > shell.cat('file.txt');
 These are the file contents


### PR DESCRIPTION
No change to logic. Now that this plugin uses `util.inspect.custom` over
the `.inspect` attribute directly (see issue #9), this rewrites the docs
accordingly.