### PR TITLE
chore: update CI to include v18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
           - 12
           - 14
           - 16
+          - 18
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
No change to logic. This updates GitHub actions to test up through node
v18.